### PR TITLE
Draft socket and selector mocking

### DIFF
--- a/connection_handler.py
+++ b/connection_handler.py
@@ -16,6 +16,14 @@ class MessageEvent:
     def __str__(self) -> str:
         return str(self.message) + ", " + str(self.address)
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        return isinstance(other, MessageEvent) and \
+            self.address == other.address and \
+            self.message == other.message
+
 class ConnectionInformation:
     """Class for keeping track of a socket and address"""
     def __init__(self, sock, addr):

--- a/connection_handler.py
+++ b/connection_handler.py
@@ -178,16 +178,8 @@ class ConnectionHandler:
         self.message_sender = MessageSender(self.logger, self.connection_information, sending_protocol_map, self.close)
 
     def _set_selector_events_mask(self, mode):
-        """Set selector to listen for events: mode is 'r', 'w', or 'rw'."""
-        if mode == "r":
-            events = selectors.EVENT_READ
-        elif mode == "w":
-            events = selectors.EVENT_WRITE
-        elif mode == "rw":
-            events = selectors.EVENT_READ | selectors.EVENT_WRITE
-        else:
-            raise ValueError(f"Invalid events mask mode {repr(mode)}.")
-        self.selector.modify(self.connection_information.sock, events, data=self)
+        """Set selector to listen for events."""
+        self.selector.modify(self.connection_information.sock, mode, data=self)
 
     def respond_to_request(self, request: Message):
         """Responds to the request message"""

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -14,7 +14,6 @@ class MockInternet:
         target.receive_message_from_socket(message)
 
     def get_socket(self, address):
-        print('self.sockets', self.sockets)
         return self.sockets[address]
 
     def connect_to_listening_socket(self, target_address, source_address):

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -1,0 +1,48 @@
+class MockTCPSocket:
+    def __init__(self):
+        """Simulates a TCP socket for testing purposes"""
+        self.address = None
+        self.receive_buffer
+        self.open_for_reading = False
+        self.open_for_writing = False
+        self.has_closed = False
+        self.peer = None
+    
+    def send(self, bytes):
+        """Simulates sending the following bytes and returns the number of bytes sent"""
+        pass
+
+    def recv(self, amount_of_bytes_to_receive: int):
+        """Retrieves at most the amount of bytes to receive from the buffer. Returns None if the peer closes"""
+        pass
+
+    def close(self):
+        """Closes the connection"""
+        self.open_for_reading = False
+        self.open_for_writing = False
+        self.has_closed = True
+
+    def connect_ex(self, address):
+        """Connects to the specified address"""
+        pass
+
+    def setblocking(self, value):
+        pass
+
+class MockListeningSocket:
+    def __init__(self):
+        """Simulates a listening socket that creates connections"""
+        self.address
+        self.is_listening = False
+
+    def setsockopt(self, *args):
+        pass
+
+    def bind(self, address):
+        self.address = address
+
+    def listen(self):
+        self.is_listening = True
+
+    def setblocking(self, value):
+        pass

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -1,3 +1,5 @@
+import connection_handler
+
 class MockInternet:
     def __init__(self):
         """Used by socket simulating classes to send information to each other"""
@@ -111,4 +113,29 @@ class MockListeningSocket:
         next_socket = self.created_sockets.pop()
         return next_socket, next_socket.get_peer_address()
 
-    
+class MockKey:
+    def __init__(self, data, address, socket=None):
+        self.data = data
+        self.fileobj = socket
+        self.address = address
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, MockKey) and self.address == other.address
+
+class MockSelector:
+    def __init__(self):
+        self.sockets = {}
+
+    def select(self, timeout=None):
+        pass
+
+    def register(self, socket, flags, data: connection_handler.ConnectionHandler):
+        key = MockKey(data, socket)
+        data._set_selector_events_mask(flags)
+        self.sockets[key] = data
+
+    def unregister(self, socket):
+        for key in self.sockets:
+            if key.fileobj == socket:
+                self.sockets.pop(key)
+                return 

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -119,8 +119,12 @@ class MockKey:
         self.fileobj = socket
         self.address = address
 
+    #The equality method and hash method must be implemented to use this as a dictionary key
     def __eq__(self, other) -> bool:
         return isinstance(other, MockKey) and self.address == other.address
+
+    def __hash__(self):
+        return hash(self.address)
 
 class MockSelector:
     def __init__(self):

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -30,7 +30,9 @@ class MockInternet:
         return socket
 
     def create_listening_socket_from_address(self, address):
-        return MockListeningSocket(self, address)
+        socket = MockListeningSocket(self, address)
+        socket.listen()
+        return socket
 
 class MockTCPSocket:
     SENDING_LIMIT = 1500
@@ -53,7 +55,7 @@ class MockTCPSocket:
 
     def recv(self, amount_of_bytes_to_receive: int):
         """Retrieves at most the amount of bytes to receive from the buffer. Returns None if the peer closes"""
-        if self.has_closed():
+        if self.has_closed:
             return None
         else:
             result = self.receive_buffer[:amount_of_bytes_to_receive]
@@ -75,6 +77,7 @@ class MockTCPSocket:
     def connect_ex(self, address):
         """Connects to the specified address"""
         self.peer = self.internet.connect_to_listening_socket(address, self.address)
+        print('self.peer', self.peer)
 
     def set_peer(self, peer):
         self.peer = peer
@@ -82,7 +85,7 @@ class MockTCPSocket:
     def setblocking(self, value):
         pass
 
-    def receive_message_from_socket(self, message, address):
+    def receive_message_from_socket(self, message):
         self.receive_buffer += message
 
     def get_address(self):
@@ -128,6 +131,7 @@ class MockListeningSocket:
             peer = self.internet.get_socket(address)
             new_socket.set_peer(peer)
             self.created_sockets.append(new_socket)
+            return new_socket
 
     def accept(self):
         next_socket = self.created_sockets.pop()

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -136,17 +136,17 @@ class MockListeningSocket:
         return False
 
 class MockKey:
-    def __init__(self, data, address, socket=None):
+    def __init__(self, data, socket):
         self.data = data
         self.fileobj = socket
-        self.address = address
+        
 
     #The equality method and hash method must be implemented to use this as a dictionary key
     def __eq__(self, other) -> bool:
-        return isinstance(other, MockKey) and self.address == other.address
+        return isinstance(other, MockKey) and self.fileobj == other.fileobj
 
     def __hash__(self):
-        return hash(self.address)
+        return hash(self.fileobj)
 
 class MockSelector:
     def __init__(self):
@@ -155,7 +155,7 @@ class MockSelector:
     def select(self, timeout=None):
         results = []
         for key in self.sockets:
-            socket = self.sockets[key]
+            socket = key.fileobj
             if socket.has_received_bytes():
                 result_key = MockKey(None, None, socket) if socket.is_listening_socket() else key
                 results.append((result_key, selectors.EVENT_READ))
@@ -180,4 +180,5 @@ class MockSelector:
         socket.set_open_for_reading(mode == selectors.EVENT_READ or is_mode_matching_both)
         socket.set_open_for_writing(mode == selectors.EVENT_WRITE or is_mode_matching_both)
 
-        
+    def close(self):
+        pass

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -22,11 +22,12 @@ class MockInternet:
         target.close()
 
 class MockTCPSocket:
+    SENDING_LIMIT = 1500
     def __init__(self, internet: MockInternet, address):
         """Simulates a TCP socket for testing purposes"""
         self.internet = internet
         self.address = address
-        self.receive_buffer
+        self.receive_buffer = b""
         self.open_for_reading = False
         self.open_for_writing = False
         self.has_closed = False
@@ -34,7 +35,9 @@ class MockTCPSocket:
     
     def send(self, message_bytes):
         """Simulates sending the following bytes and returns the number of bytes sent"""
-        self.internet.message_socket(self.peer.get_address(), message_bytes)
+        bytes_to_send = message_bytes[:self.SENDING_LIMIT]
+        self.internet.message_socket(self.peer.get_address(), bytes_to_send)
+        return len(bytes_to_send)
 
     def recv(self, amount_of_bytes_to_receive: int):
         """Retrieves at most the amount of bytes to receive from the buffer. Returns None if the peer closes"""
@@ -70,6 +73,9 @@ class MockTCPSocket:
 
     def get_peer_address(self):
         return self.peer.get_address()
+
+    def has_received_bytes(self):
+        return len(self.receive_buffer) > 0
 
 
 class MockListeningSocket:

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -190,3 +190,6 @@ class MockSelector:
 
     def close(self):
         pass
+
+    def get_map(self):
+        return self.sockets

--- a/mock_socket.py
+++ b/mock_socket.py
@@ -14,6 +14,7 @@ class MockInternet:
         target.receive_message_from_socket(message)
 
     def get_socket(self, address):
+        print('self.sockets', self.sockets)
         return self.sockets[address]
 
     def connect_to_listening_socket(self, target_address, source_address):
@@ -24,8 +25,10 @@ class MockInternet:
         target = self.sockets[address]
         target.close()
 
-    def create_socket_from_address(self, address):
-        return MockTCPSocket(self, address)
+    def create_socket_from_address(self, address, target_address):
+        socket = MockTCPSocket(self, address)
+        socket.connect_ex(target_address)
+        return socket
 
     def create_listening_socket_from_address(self, address):
         return MockListeningSocket(self, address)
@@ -36,6 +39,7 @@ class MockTCPSocket:
         """Simulates a TCP socket for testing purposes"""
         self.internet = internet
         self.address = address
+        self.internet.register_socket(self.address, self)
         self.receive_buffer = b""
         self.open_for_reading = False
         self.open_for_writing = False
@@ -100,6 +104,7 @@ class MockListeningSocket:
         """Simulates a listening socket that creates connections"""
         self.internet = internet
         self.address = address
+        self.internet.register_socket(self.address, self)
         self.last_port_used = self.address[1]
         self.is_listening = False
         self.created_sockets = []

--- a/protocol.py
+++ b/protocol.py
@@ -12,6 +12,14 @@ class Message:
     def __str__(self):
         return f"Type Code: {self.type_code}, Values: {self.values}"
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        return isinstance(other, Message) and \
+            other.type_code == self.type_code and \
+            other.values == self.values
+
 class ProtocolMap:
     """Maps between type codes and protocols"""
     def __init__(self, protocols):

--- a/server.py
+++ b/server.py
@@ -63,7 +63,7 @@ class Server:
         self.connection_table = ConnectionTable()
         self.usernames_to_connections = {}
         self.game_handler = GameHandler()
-        listening_socket = create_listening_socket((host, port))
+        listening_socket = self.create_socket_from_address((host, port))
         self.selector.register(listening_socket, selectors.EVENT_READ, data=None)
         self._create_protocol_callback_handler()
 

--- a/server.py
+++ b/server.py
@@ -213,6 +213,7 @@ class Server:
                 events = self.selector.select(timeout=None)
                 for key, mask in events:
                     if key.data is None:
+                        print("success!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
                         self.accept_wrapper(key.fileobj)
                     else:
                         message = key.data

--- a/server.py
+++ b/server.py
@@ -66,6 +66,7 @@ class Server:
         listening_socket = self.create_socket_from_address((host, port))
         self.selector.register(listening_socket, selectors.EVENT_READ, data=None)
         self._create_protocol_callback_handler()
+        self.should_close = False
 
     def _create_protocol_callback_handler(self):
         self.protocol_callback_handler = protocol.ProtocolCallbackHandler()
@@ -207,9 +208,12 @@ class Server:
         connection_table_entry = ConnectionTableEntry(connection_handler, AssociatedConnectionState())
         self.connection_table.insert_entry(connection_table_entry)
 
+    def close(self):
+        self.should_close = True
+
     def listen_for_socket_events(self):
         try:
-            while True:
+            while not self.should_close:
                 events = self.selector.select(timeout=None)
                 for key, mask in events:
                     if key.data is None:

--- a/server.py
+++ b/server.py
@@ -217,7 +217,6 @@ class Server:
                 events = self.selector.select(timeout=None)
                 for key, mask in events:
                     if key.data is None:
-                        print("success!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
                         self.accept_wrapper(key.fileobj)
                     else:
                         message = key.data

--- a/test_communication.py
+++ b/test_communication.py
@@ -1,9 +1,10 @@
 from server import Server
-from client import Client
+from client import Client, run_selector_loop
 from mock_socket import MockInternet, MockSelector, MockListeningSocket, MockTCPSocket
 from logging_utilities import PrimaryMemoryLogger
 import protocol_definitions
 from protocol import Message
+import connection_handler
 
 import unittest
 from threading import Thread
@@ -24,10 +25,13 @@ class TestMocking(unittest.TestCase):
             server_listening_thread.start()
             client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function= lambda x: internet.create_socket_from_address(x, server_address))
             client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
+            run_selector_loop(client_selector, client_logger)
             server.close()
         except Exception as exception:
             server.close()
             raise exception
+        results = client_logger.get_log(connection_handler.RECEIVING_MESSAGE_LOG_CATEGORY)
+        print('results', results)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_communication.py
+++ b/test_communication.py
@@ -20,8 +20,12 @@ class TestMocking(unittest.TestCase):
         client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function=internet.create_socket_from_address)
         server = Server('localhost', 9090, server_selector, server_logger, 'testing.db', internet.create_listening_socket_from_address)
         server_listening_thread = Thread(target=server.listen_for_socket_events)
-        server_listening_thread.start()
-        client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
+        try:
+            server_listening_thread.start()
+            client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
+        except Exception as exception:
+            server.close()
+            raise exception
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_communication.py
+++ b/test_communication.py
@@ -24,6 +24,7 @@ class TestMocking(unittest.TestCase):
             server_listening_thread.start()
             client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function= lambda x: internet.create_socket_from_address(x, server_address))
             client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
+            server.close()
         except Exception as exception:
             server.close()
             raise exception

--- a/test_communication.py
+++ b/test_communication.py
@@ -1,4 +1,4 @@
-from server import Server
+from server import Server, help_messages
 from client import Client, run_selector_loop
 from mock_socket import MockInternet, MockSelector, MockListeningSocket, MockTCPSocket
 from logging_utilities import PrimaryMemoryLogger
@@ -12,6 +12,7 @@ from threading import Thread
 
 class TestMocking(unittest.TestCase):
     def test_can_send_messages_back_and_forth(self):
+        expected_message_event = connection_handler.MessageEvent(Message(0, {'text': help_messages[""]}), ('200', 19))
         client_logger = PrimaryMemoryLogger()
         server_logger = PrimaryMemoryLogger()
         internet = MockInternet()
@@ -31,7 +32,9 @@ class TestMocking(unittest.TestCase):
             server.close()
             raise exception
         results = client_logger.get_log(connection_handler.RECEIVING_MESSAGE_LOG_CATEGORY)
+        actual_message_event = results[0]
         print('results', results)
+        self.assertEqual(expected_message_event, actual_message_event)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_communication.py
+++ b/test_communication.py
@@ -1,0 +1,25 @@
+from server import Server
+from client import Client
+from mock_socket import MockInternet, MockSelector, MockListeningSocket, MockTCPSocket
+from logging_utilities import PrimaryMemoryLogger
+import protocol_definitions
+from protocol import Message
+
+import unittest
+
+
+
+class TestMocking(unittest.TestCase):
+    def test_can_send_messages_back_and_forth(self):
+        client_logger = PrimaryMemoryLogger()
+        server_logger = PrimaryMemoryLogger()
+        internet = MockInternet()
+        client_selector = MockSelector()
+        server_selector = MockSelector()
+        client_output = []
+        client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function=internet.create_socket_from_address)
+        server = Server('localhost', 9090, server_selector, server_logger, 'testing.db', internet.create_listening_socket_from_address)
+        client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_communication.py
+++ b/test_communication.py
@@ -6,7 +6,7 @@ import protocol_definitions
 from protocol import Message
 
 import unittest
-
+from threading import Thread
 
 
 class TestMocking(unittest.TestCase):
@@ -19,6 +19,8 @@ class TestMocking(unittest.TestCase):
         client_output = []
         client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function=internet.create_socket_from_address)
         server = Server('localhost', 9090, server_selector, server_logger, 'testing.db', internet.create_listening_socket_from_address)
+        server_listening_thread = Thread(target=server.listen_for_socket_events)
+        server_listening_thread.start()
         client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
 
 if __name__ == '__main__':

--- a/test_communication.py
+++ b/test_communication.py
@@ -17,11 +17,12 @@ class TestMocking(unittest.TestCase):
         client_selector = MockSelector()
         server_selector = MockSelector()
         client_output = []
-        client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function=internet.create_socket_from_address)
+        server_address = ('localhost', 9090)
         server = Server('localhost', 9090, server_selector, server_logger, 'testing.db', internet.create_listening_socket_from_address)
         server_listening_thread = Thread(target=server.listen_for_socket_events)
         try:
             server_listening_thread.start()
+            client = Client('200', 19, client_selector, client_logger, output_text_function=lambda x: client_output.append(x), socket_creation_function= lambda x: internet.create_socket_from_address(x, server_address))
             client.send_message(Message(protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE, []))
         except Exception as exception:
             server.close()


### PR DESCRIPTION
Draft the mocking of the socket and selector and add a simple, messy test. Better code will need to be written to allow for cleaner and more automated testing. The current test requires using control-c to escape the client selector loop.