### PR TITLE
fixed the dictionary issue for python 3.11

### DIFF
--- a/server.py
+++ b/server.py
@@ -89,7 +89,7 @@ class Server:
             text = help_messages[label]
             type_code = protocol_definitions.BASE_HELP_MESSAGE_PROTOCOL_TYPE_CODE
         else:
-            text = f"Did not recognize help topic {label}!\n{help_messages[""]}"
+            text = f"Did not recognize help topic {label}!\n{help_messages['']}"
             type_code = protocol_definitions.HELP_MESSAGE_PROTOCOL_TYPE_CODE
         values = (text,)
         message = Message(type_code, values)


### PR DESCRIPTION
the help topic message was not compatible with python 3.11, so I changed the double quotes to single quotes.
closes #84 